### PR TITLE
feat(checkbox): Add 'indeterminate' prop to checkbox

### DIFF
--- a/src/app/data-table/data-table/data-table.component.html
+++ b/src/app/data-table/data-table/data-table.component.html
@@ -70,7 +70,7 @@
     <thead class="fr-data-table__thead" *ngIf="columnsComponent">
       <tr class="fr-data-table__thead-row">
         <td class="fr-data-table__thead-checkbox" [hidden]="!selectable">
-          <fr-checkbox [(ngModel)]="checkAllFlag" (change)="checkAll()"></fr-checkbox>
+          <fr-checkbox [(ngModel)]="checkAllFlag" [indeterminate]="isPartialSelect()" (change)="checkAll()"></fr-checkbox>
         </td>
         <th *ngFor="let column of columns; let i = index"
           class="fr-data-table__thead-column"

--- a/src/app/data-table/data-table/data-table.component.ts
+++ b/src/app/data-table/data-table/data-table.component.ts
@@ -186,6 +186,19 @@ export class FrDataTableComponent implements AfterContentInit, OnDestroy {
     });
   }
 
+  public isPartialSelect(): boolean {
+    const trueCount = Object.values(this.checkedRowIndices).filter(v => v).length;
+    if (trueCount === this.rows.length) {
+      this._turnOnCheckAllFlag();
+      return false;
+    }
+    return trueCount !== 0;
+  }
+
+  private _turnOnCheckAllFlag(): void {
+    this.checkAllFlag = true;
+  }
+
   public checkAll(): void {
     Object.keys(this.checkedRowIndices).forEach((index) => {
       this.checkedRowIndices[index] = this.checkAllFlag;

--- a/src/app/forms/checkbox/checkbox.component.html
+++ b/src/app/forms/checkbox/checkbox.component.html
@@ -2,17 +2,20 @@
   <div class="fr-checkbox-box-container">
     <span class="fr-checkbox__square"
       [class.fr-checkbox__square--checked]="value"
+      [class.fr-checkbox__square--indeterminate]="indeterminate"
       [class.fr-checkbox__square--focused]="isFocused"
       [class.fr-checkbox__square--disabled]="disabled">
     </span>
     <span class="fr-checkbox__background"
       [class.fr-checkbox__background--checked]="value"
+      [class.fr-checkbox__background--indeterminate]="indeterminate"
       [class.fr-checkbox__background--disabled]="disabled">
       <svg class="fr-checkbox-checkmark"
         viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path class="fr-checkbox-checkmark-path"
           [@checkmarkState]="checkmarkState"
           d="M 22 5 L 9.508 19 L 2 11.78" style="fill: none;"/>
+        <path *ngIf="indeterminate" class="fr-checkbox-indeterminate-path" style="fill: none;" d="M 2 12 L 8.853 12 L 22 12"/>
       </svg>
     </span>
     <span class="fr-checkbox__ripple-container">
@@ -22,6 +25,7 @@
   <input #input type="checkbox"
          name="{{name}}"
          class="fr-checkbox__input"
+         [indeterminate]="indeterminate"
          (click)="onClick($event)"
          (change)="onchange($event)"
          (focus)="onFocus($event)"

--- a/src/app/forms/checkbox/checkbox.component.scss
+++ b/src/app/forms/checkbox/checkbox.component.scss
@@ -47,7 +47,7 @@ input[type="checkbox"] {
     background: transparent;
     transition-property: background;
     transition-duration: 0.3s;
-    &--checked {
+    &--checked, &--indeterminate {
       color: $white;
       background: $secondary;
       border: 2px solid $secondary;
@@ -68,7 +68,7 @@ input[type="checkbox"] {
     bottom: 0px;
     padding: 2px;
     border-radius: 2px;
-    &--checked {
+    &--checked, &--indeterminate {
       background: $secondary;
     }
   }
@@ -105,6 +105,11 @@ input[type="checkbox"] {
   &-checkmark {
     width: 100%;
     height: 100%;
+  }
+  &-indeterminate-path {
+    fill: none;
+    stroke: $white;
+    stroke-width: 2px;
   }
   &-label-text {
     margin: 0 8px;

--- a/src/app/forms/checkbox/checkbox.component.spec.ts
+++ b/src/app/forms/checkbox/checkbox.component.spec.ts
@@ -56,4 +56,15 @@ describe('FrCheckboxComponent', () => {
     component.onBlur(new Event('click'));
     expect(component.isFocused).toBeFalsy();
   });
+
+  it ('should set indeterminate flag false when it is clicked', () => {
+    component.indeterminate = true;
+    expect(component.indeterminate).toBeTruthy();
+
+    component.onClick(new Event('click'));
+    expect(component.indeterminate).toBeFalsy();
+
+    component.onClick(new Event('click'));
+    expect(component.indeterminate).toBeFalsy();
+  });
 });

--- a/src/app/forms/checkbox/checkbox.component.ts
+++ b/src/app/forms/checkbox/checkbox.component.ts
@@ -65,7 +65,6 @@ export class FrCheckboxComponent implements OnInit, ControlValueAccessor {
 
   @Input() label: string;
   @Input() name: string;
-  @Input() indeterminate: boolean;
 
   @Output() change: EventEmitter<FrCheckboxChange> = new EventEmitter<FrCheckboxChange>();
 
@@ -75,9 +74,18 @@ export class FrCheckboxComponent implements OnInit, ControlValueAccessor {
   private _onChangeCallback: (_: any) => void = noop;
   private _onTouchedCallback: () => void = noop;
   private _isDisabled = false;
+  private _indeterminate = false;
 
   public isRippleOn = false;
   public isFocused: boolean;
+
+  @Input()
+  set indeterminate(_indeterminate: boolean) {
+    this._indeterminate = _indeterminate;
+  }
+  get indeterminate(): boolean {
+    return this._indeterminate;
+  }
 
   private _checkmarkState = CHECKMARK_VOID;
 

--- a/src/app/forms/checkbox/checkbox.component.ts
+++ b/src/app/forms/checkbox/checkbox.component.ts
@@ -65,6 +65,7 @@ export class FrCheckboxComponent implements OnInit, ControlValueAccessor {
 
   @Input() label: string;
   @Input() name: string;
+  @Input() indeterminate: boolean;
 
   @Output() change: EventEmitter<FrCheckboxChange> = new EventEmitter<FrCheckboxChange>();
 
@@ -109,6 +110,7 @@ export class FrCheckboxComponent implements OnInit, ControlValueAccessor {
     if (this.disabled) {
       return;
     }
+    this.indeterminate = false;
     this.value = !this.value;
     this.isRippleOn = true;
     setTimeout(() => this.isRippleOn = false, 1000);

--- a/src/demo/forms-demo.component.html
+++ b/src/demo/forms-demo.component.html
@@ -32,6 +32,7 @@
       <td>
         <fr-form-group label="checkbox">
           <fr-checkbox *ngFor="let checkbox of formGroup.controls['checkboxes']['controls']; let i = index" [formControl]="checkbox"
+            [indeterminate]="checkboxes[i].indeterminate"
             (change)="onCheckboxChange($event)">
             {{checkboxes[i]['name']}}
           </fr-checkbox>

--- a/src/demo/forms-demo.component.ts
+++ b/src/demo/forms-demo.component.ts
@@ -29,8 +29,9 @@ export class FormsDemoComponent {
   ];
   checkboxes = [
     { name: 'check1', indeterminate: false },
-    { name: 'check2', indeterminate: true  },
-    { name: 'check3', indeterminate: false }
+    { name: 'check2', indeterminate: false },
+    { name: 'check3', indeterminate: false },
+    { name: 'check4 (indeterminate)', indeterminate: true },
   ];
   options = [
     { label: 'Option1 number', value: 1 },
@@ -62,6 +63,7 @@ export class FormsDemoComponent {
         select: '',
         radio: [],
         checkboxes: new FormArray([
+          new FormControl(false),
           new FormControl(false),
           new FormControl(false),
           new FormControl(false)

--- a/src/demo/forms-demo.component.ts
+++ b/src/demo/forms-demo.component.ts
@@ -28,9 +28,9 @@ export class FormsDemoComponent {
     { label: 'Object', value: { key: 'value' } }
   ];
   checkboxes = [
-    { name: 'check1' },
-    { name: 'check2' },
-    { name: 'check3' }
+    { name: 'check1', indeterminate: false },
+    { name: 'check2', indeterminate: true  },
+    { name: 'check3', indeterminate: false }
   ];
   options = [
     { label: 'Option1 number', value: 1 },


### PR DESCRIPTION
<!-- THIS TEMPLATE IS INSPIRED BY angular/angular https://github.com/angular/angular/blob/master/.github/PULL_REQUEST_TEMPLATE.md -->
## Summary


## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Module or Component

`FrCheckboxComponent` and `FrDataTableComponent`

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is no way to work with `indeterminate` property.

Close: #1 

## What is the new behavior?

- Make it possible to pass `indeterminate` to `fr-checkbox`
- Display `-` in a checkbox
- Make `selectAll` checkbox on data-table component work with `indeterminate` checkbox if some part of data-table rows are selected

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Additional Information
