### PR TITLE
docs(readme): Display github actions badge instead of circleci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Francette
 
-[![CircleCI](https://circleci.com/gh/chloe463/francette.svg?style=shield)](https://circleci.com/gh/chloe463/francette)
+![Main](https://github.com/chloe463/francette/workflows/Main/badge.svg)
 [![npm version](https://badge.fury.io/js/francette.svg)](https://badge.fury.io/js/francette)
 
 Simple components and style sheets for Angular 2.0 or higher.


### PR DESCRIPTION
## Why & What

Update readme